### PR TITLE
Bugfix/component segfault

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -46,5 +46,12 @@ add_executable(babs-ecs
     src/main.cpp
     ${TESTED_SOURCES}
 )
+
+# benchmark
+add_executable(babs-benchmark
+    src/benchmark.cpp
+    ${TESTED_SOURCES}
+)
+
 add_dependencies(babs-ecs tests)
 

--- a/src/Manager.hpp
+++ b/src/Manager.hpp
@@ -23,7 +23,6 @@ struct Entity
 	}
 };
 
-// This is needed to use Entity as a key in a map.
 struct EntityComparer
 {
 	bool operator() (const Entity& lhs, const Entity& rhs) const
@@ -32,7 +31,6 @@ struct EntityComparer
 	}
 };
 
-// Exists to satisfying compiler warnings
 class BaseContainer
 {
 public:
@@ -40,7 +38,6 @@ public:
 	virtual ~BaseContainer() {};
 };
 
-// This would be the concrete type created by RegisterComponent and inserted into the map
 template <typename T>
 class ComponentContainer : public BaseContainer
 {
@@ -200,15 +197,10 @@ std::vector<std::string> ECS::GetComponentNames(std::vector<std::string> names, 
 	std::string name = this->GetComponentName(std::forward<T>(type));
 	names.push_back(name);
 
-	// recursion basically - we keep showing up in this function, and eventually
-	// we hit the base case of one type and no list of types, so we get sent to the
-	// function above and then everything returns back to the caller.
+	// Continue getting component neames until we are out of template arguments and return the list
 	return this->GetComponentNames(names, std::forward<Ts>(types)...);
-
-	//return names;
 }
 
-/// USED
 template<typename ...Ts>
 inline std::vector<Entity*> ECS::EntitiesWith(Ts&& ...types)
 {

--- a/src/Manager.hpp
+++ b/src/Manager.hpp
@@ -91,9 +91,6 @@ private:
 
 	std::vector<std::string> GetComponentNames(std::vector<std::string> names);
 
-	template <typename T>
-	std::vector<std::string> GetComponentNames(std::vector<std::string> names, T type);
-
 	template <typename T, typename ...Ts>
 	std::vector<std::string> GetComponentNames(std::vector<std::string> names, T type, Ts... types);
 
@@ -197,15 +194,6 @@ std::vector<std::string> ECS::GetComponentNames(std::vector<std::string> names)
 	return names;
 }
 
-template <typename T>
-std::vector<std::string> ECS::GetComponentNames(std::vector<std::string> names, T type)
-{
-	std::string name = this->GetComponentName(std::forward<T>(type));
-	names.push_back(name);
-
-	return names;
-}
-
 template <typename T, typename ...Ts>
 std::vector<std::string> ECS::GetComponentNames(std::vector<std::string> names, T type, Ts... types)
 {
@@ -215,11 +203,12 @@ std::vector<std::string> ECS::GetComponentNames(std::vector<std::string> names, 
 	// recursion basically - we keep showing up in this function, and eventually
 	// we hit the base case of one type and no list of types, so we get sent to the
 	// function above and then everything returns back to the caller.
-	this->GetComponentNames(names, std::forward<Ts>(types)...);
+	return this->GetComponentNames(names, std::forward<Ts>(types)...);
 
-	return names;
+	//return names;
 }
 
+/// USED
 template<typename ...Ts>
 inline std::vector<Entity*> ECS::EntitiesWith(Ts&& ...types)
 {

--- a/src/Manager.hpp
+++ b/src/Manager.hpp
@@ -9,8 +9,35 @@
 #include <typeinfo>
 #include <vector>
 
-typedef uint32_t Entity;
-	
+
+struct Entity
+{
+	bitfield::Bitfield bitfield;
+	int32_t UUID;
+
+	Entity(uint32_t uuid)
+	{
+		bitfield = 0;
+		UUID = uuid;
+	}
+
+	// Makes compiler happy
+	Entity()
+	{
+		bitfield = 0;
+		UUID = 0;
+	}
+};
+
+// This is needed to use Entity as a key in a map.
+struct EntityComparer
+{
+	bool operator() (const Entity& lhs, const Entity& rhs) const
+	{
+		return lhs.UUID < rhs.UUID;
+	}
+};
+
 // Exists to satisfying compiler warnings
 class BaseContainer
 {
@@ -26,7 +53,7 @@ class ComponentContainer : public BaseContainer
 public:
 	ComponentContainer() {};
 	virtual ~ComponentContainer() {};
-	std::map<Entity, T> data;
+	std::map<Entity, T, EntityComparer> data;
 };
 
 class ECS {
@@ -39,11 +66,9 @@ public:
 
 	Entity CreateEntity()
 	{
-		Entity e = this->entityIndex;
+		Entity e = Entity(this->entityIndex);
 		this->entityIndex++;
-
-		bitfield::Bitfield bit = 0;
-		this->entities[e] = bit;
+		this->entities.push_back(e);
 
 		return e;
 	}
@@ -58,11 +83,11 @@ public:
 	T* GetComponent(Entity entity, T component);
 
 	template<typename... Ts>
-	std::vector<Entity> EntitiesWith(Ts&&... types);
+	std::vector<Entity*> EntitiesWith(Ts&& ... types);
 private:
-	Entity entityIndex;
+	int32_t entityIndex;
 	bitfield::Bitfield bitIndex;
-	std::map<Entity, bitfield::Bitfield> entities;
+	std::vector<Entity> entities;
 
 	std::map<std::string, BaseContainer*> components;
 	std::map<std::string, bitfield::Bitfield> componentIndex;
@@ -70,13 +95,13 @@ private:
 	template <typename T>
 	std::string GetComponentName(T component);
 
-    std::vector<std::string> GetComponentNames(std::vector<std::string> names);
+	std::vector<std::string> GetComponentNames(std::vector<std::string> names);
 
-    template <typename T>
-    std::vector<std::string> GetComponentNames(std::vector<std::string> names, T type);
+	template <typename T>
+	std::vector<std::string> GetComponentNames(std::vector<std::string> names, T type);
 
-    template <typename T, typename ...Ts>
-    std::vector<std::string> GetComponentNames(std::vector<std::string> names, T type, Ts... types);
+	template <typename T, typename ...Ts>
+	std::vector<std::string> GetComponentNames(std::vector<std::string> names, T type, Ts... types);
 };
 
 template<typename T>
@@ -98,11 +123,11 @@ inline void ECS::RegisterComponent(T component)
 			throw std::out_of_range("Exceeded available flags for the bitfield! (max 32 b/c uint32)");
 		}
 
-		std::cout << "added " << componentName << " to ECS" << std::endl;
+		//std::cout << "added " << componentName << " to ECS" << std::endl;
 	}
 	else // key already registered!
 	{
-		std::cout << componentName << " is already a registered component!" << std::endl;
+		//std::cout << componentName << " is already a registered component!" << std::endl;
 	}
 }
 
@@ -114,13 +139,26 @@ inline void ECS::AddComponent(Entity entity, T component)
 	container->data[entity] = component;
 	int componentFlag = componentIndex[componentName];
 
-	entities.insert(std::pair<Entity, bitfield::Bitfield>(entities[entity], componentFlag));
+	//entities.insert(std::pair<Entity, bitfield::Bitfield>(entities[entity], componentFlag));
 	components[componentName] = container;
 
-	entities[entity] = bitfield::Set(entities[entity], componentFlag);
+	bool entityFound = false;
+	for (Entity& e : this->entities)
+	{
+		if (e.UUID == entity.UUID)
+		{
+			entityFound = true;
+			e.bitfield = bitfield::Set(e.bitfield, componentFlag);
+		}
+	}
 
-	std::cout << "added data for " << componentName << " to ECS for entity " << entity << std::endl;
-	std::cout << " container has " << container->data.size() << " components in it" << std::endl;
+	if (!entityFound)
+	{
+		throw std::runtime_error("Failed to find entity to add component to");
+	}
+
+	//std::cout << "added data for " << componentName << " to ECS for entity " << entity << std::endl;
+	//std::cout << " container has " << container->data.size() << " components in it" << std::endl;
 }
 
 template<typename T>
@@ -128,11 +166,17 @@ inline T* ECS::GetComponent(Entity entity, T component)
 {
 	std::string componentName = this->GetComponentName(component);
 	int componentFlag = componentIndex[componentName];
-
-	if (bitfield::Has(entities[entity], componentFlag))
+	
+	for (Entity e : this->entities)
 	{
-		ComponentContainer<T>* container = dynamic_cast<ComponentContainer<T>*>(this->components[componentName]);
-		return &container->data[entity];
+		if (e.UUID = entity.UUID)
+		{
+			if (bitfield::Has(e.bitfield, componentFlag))
+			{
+				ComponentContainer<T>* container = dynamic_cast<ComponentContainer<T>*>(this->components[componentName]);
+				return &container->data[entity];
+			}
+		}
 	}
 
 	return NULL;
@@ -140,55 +184,56 @@ inline T* ECS::GetComponent(Entity entity, T component)
 
 std::vector<std::string> ECS::GetComponentNames(std::vector<std::string> names)
 {
-    return names;
+	return names;
 }
 
 template <typename T>
 std::vector<std::string> ECS::GetComponentNames(std::vector<std::string> names, T type)
 {
-    std::string name = this->GetComponentName(std::forward<T>(type));
-    names.push_back(name);
+	std::string name = this->GetComponentName(std::forward<T>(type));
+	names.push_back(name);
 
-    return names;
+	return names;
 }
 
 template <typename T, typename ...Ts>
 std::vector<std::string> ECS::GetComponentNames(std::vector<std::string> names, T type, Ts... types)
 {
-    std::string name = this->GetComponentName(std::forward<T>(type));
-    names.push_back(name);
-    
-    // recursion basically - we keep showing up in this function, and eventually
-    // we hit the base case of one type and no list of types, so we get sent to the
-    // function above and then everything returns back to the caller.
-    this->GetComponentNames(names, std::forward<Ts>(types)...);
+	std::string name = this->GetComponentName(std::forward<T>(type));
+	names.push_back(name);
 
-    return names;
+	// recursion basically - we keep showing up in this function, and eventually
+	// we hit the base case of one type and no list of types, so we get sent to the
+	// function above and then everything returns back to the caller.
+	this->GetComponentNames(names, std::forward<Ts>(types)...);
+
+	return names;
 }
 
 template<typename ...Ts>
-inline std::vector<Entity> ECS::EntitiesWith(Ts&& ...types)
+inline std::vector<Entity*> ECS::EntitiesWith(Ts&& ...types)
 {
-    // build bitfield flags for this search
-    std::vector<std::string> componentNames;
-    componentNames = this->GetComponentNames(componentNames, std::forward<Ts>(types)...);
+	// build bitfield flags for this search
+	std::vector<std::string> componentNames;
+	componentNames = this->GetComponentNames(componentNames, std::forward<Ts>(types)...);
 
-    bitfield::Bitfield field = 0;
-    for (auto name : componentNames)
-    {
-        field = bitfield::Set(field, this->componentIndex[name]);
-    }
+	bitfield::Bitfield field = 0;
+	for (auto name : componentNames)
+	{
+		field = bitfield::Set(field, this->componentIndex[name]);
+	}
 
-    // search time
-    std::vector<Entity> requestedEntities;
-    for (auto mapEntry : this->entities) {
-        std::cout << "  checking entity " << mapEntry.first << std::endl;
-        if (bitfield::Has(mapEntry.second, field)) {
-            std::cout << "    adding" << std::endl;
-            requestedEntities.push_back(mapEntry.first);
-        }
-    }
-		
+	// search time
+	std::vector<Entity*> requestedEntities;
+	requestedEntities.reserve(this->entities.size());
+	for (auto e : this->entities) {
+		//std::cout << "  checking entity " << mapEntry.first << std::endl;
+		if (bitfield::Has(e.bitfield, field)) {
+			//std::cout << "    adding" << std::endl;
+			requestedEntities.emplace_back(&e);
+		}
+	}
+
 	return requestedEntities;
 }
 

--- a/src/Manager.hpp
+++ b/src/Manager.hpp
@@ -20,13 +20,6 @@ struct Entity
 		bitfield = 0;
 		UUID = uuid;
 	}
-
-	// Makes compiler happy
-	Entity()
-	{
-		bitfield = 0;
-		UUID = 0;
-	}
 };
 
 // This is needed to use Entity as a key in a map.
@@ -122,12 +115,6 @@ inline void ECS::RegisterComponent(T component)
 		{
 			throw std::out_of_range("Exceeded available flags for the bitfield! (max 32 b/c uint32)");
 		}
-
-		//std::cout << "added " << componentName << " to ECS" << std::endl;
-	}
-	else // key already registered!
-	{
-		//std::cout << componentName << " is already a registered component!" << std::endl;
 	}
 }
 
@@ -139,7 +126,6 @@ inline void ECS::AddComponent(Entity entity, T component)
 	container->data[entity] = component;
 	int componentFlag = componentIndex[componentName];
 
-	//entities.insert(std::pair<Entity, bitfield::Bitfield>(entities[entity], componentFlag));
 	components[componentName] = container;
 
 	bool entityFound = false;
@@ -156,9 +142,6 @@ inline void ECS::AddComponent(Entity entity, T component)
 	{
 		throw std::runtime_error("Failed to find entity to add component to");
 	}
-
-	//std::cout << "added data for " << componentName << " to ECS for entity " << entity << std::endl;
-	//std::cout << " container has " << container->data.size() << " components in it" << std::endl;
 }
 
 template<typename T>
@@ -169,7 +152,7 @@ inline T* ECS::GetComponent(Entity entity, T component)
 	
 	for (Entity e : this->entities)
 	{
-		if (e.UUID = entity.UUID)
+		if (e.UUID == entity.UUID)
 		{
 			if (bitfield::Has(e.bitfield, componentFlag))
 			{
@@ -223,13 +206,10 @@ inline std::vector<Entity*> ECS::EntitiesWith(Ts&& ...types)
 		field = bitfield::Set(field, this->componentIndex[name]);
 	}
 
-	// search time
 	std::vector<Entity*> requestedEntities;
 	requestedEntities.reserve(this->entities.size());
-	for (auto e : this->entities) {
-		//std::cout << "  checking entity " << mapEntry.first << std::endl;
+	for (auto& e : this->entities) {
 		if (bitfield::Has(e.bitfield, field)) {
-			//std::cout << "    adding" << std::endl;
 			requestedEntities.emplace_back(&e);
 		}
 	}

--- a/src/benchmark.cpp
+++ b/src/benchmark.cpp
@@ -1,0 +1,151 @@
+//#include <entityplus/entity.h>
+//#include <entityx/entityx.h>
+#include <chrono>
+#include <iostream>
+#include <string>
+
+#include "Manager.hpp"
+
+class Timer {
+	std::chrono::high_resolution_clock::time_point start;
+	std::string name;
+public:
+	Timer(std::string name)
+	{
+		this->start = std::chrono::high_resolution_clock::now();
+		this->name = name;
+	}
+	~Timer()
+	{
+		auto end = std::chrono::high_resolution_clock::now();
+		std::cout << this->name << std::chrono::duration_cast<std::chrono::milliseconds>(end - start).count() << "\n";
+	}
+};
+
+struct Identity
+{
+	int uuid;
+};
+
+struct Tag {};
+
+void babsEcsTest(int entityCount, int iterationCount, int tagProb)
+{
+	ECS ecs;
+	ecs.RegisterComponent(Identity());
+	ecs.RegisterComponent(Tag());
+
+	//Entity entity1 = ecs.CreateEntity();
+	   //Identity ident{ "babs1" };
+	   //ecs.AddComponent(entity1, ident);
+
+	std::cout << "Babs ECS\n";
+	{
+		Timer timer("Add entities: ");
+		for (int i = 0; i < entityCount; ++i) {
+			auto entity = ecs.CreateEntity();
+			ecs.AddComponent(entity, Identity{ i });
+
+			if (i % tagProb == 0)
+			{
+				ecs.AddComponent(entity, Tag{});
+			}
+		}
+	}
+	{
+		Timer timer("For_each entities w/ Identity: ");
+		std::uint64_t sum = 0;
+		for (int i = 0; i < iterationCount; ++i) {
+			auto entities = ecs.EntitiesWith(Identity{});
+			for (auto entity : entities)
+			{
+				sum++;
+			}
+		}
+		std::cout << sum << "\n";
+	}
+	{
+		Timer timer("For_each entities w/ Tag: ");
+		std::uint64_t sum = 0;
+		for (int i = 0; i < iterationCount; ++i) {
+			auto entities = ecs.EntitiesWith(Tag{});
+			for (auto entity : entities)
+			{
+				sum++;
+			}
+		}
+		std::cout << sum << "\n";
+	}
+}
+
+// void entPlusTest(int entityCount, int iterationCount, int tagProb) {
+//  using namespace entityplus;
+//  entity_manager<component_list<int>, tag_list<struct Tag>> em;
+//  em.create_grouping<int, Tag>();
+//  std::cout << "EntityPlus\n";
+//  {
+//   Timer timer("Add entities: ");
+//   for (int i = 0; i < entityCount; ++i) {
+//    auto ent = em.create_entity();
+//    ent.add_component<int>(i);
+//    if (i % tagProb == 0)
+//     ent.set_tag<Tag>(true);
+//   }
+//  }
+//  {
+//   Timer timer("For_each entities: ");
+//   std::uint64_t sum = 0;
+//   for (int i = 0; i < iterationCount; ++i) {
+//    em.for_each<Tag, int>([&](auto ent, auto i) {
+//     sum += i;
+//    });
+//   }
+//   std::cout << sum << "\n";
+//  }
+// }
+
+// void entXTest(int entityCount, int iterationCount, int tagProb) {
+//  using namespace entityx;
+//  struct Tag {};
+//  entityx::EntityX ex;
+//  std::cout << "EntityX\n";
+//  {
+//   Timer timer("Add entities: ");
+//   for (int i = 0; i < entityCount; ++i) {
+//    auto ent = ex.entities.create();
+//    ent.assign<int>(i);
+//    if (i % tagProb == 0)
+//     ent.assign<Tag>();
+//   }
+//  }
+//  {
+//   Timer timer("For_each entities: ");
+//   std::uint64_t sum = 0;
+//   for (int i = 0; i < iterationCount; ++i) {
+//    ex.entities.each<Tag, int>([&](auto ent, auto &, auto i) {
+//     sum += i;
+//    });
+//   }
+//   std::cout << sum << "\n";
+//  }
+// }
+
+void runTest(int entityCount, int iterationCount, int tagProb) {
+	std::cout << "Count: " << entityCount
+		<< " ItrCount: " << iterationCount
+		<< " TagProb: " << tagProb << "\n";
+	babsEcsTest(entityCount, iterationCount, tagProb);
+	//entPlusTest(entityCount, iterationCount, tagProb);
+	//std::cout << "\n";
+	//entXTest(entityCount, iterationCount, tagProb);
+	std::cout << "\n\n";
+}
+
+int main() {
+	runTest(1'000, 1'000'000, 3);
+	//runTest(10'000, 1'000'000, 3);
+	//runTest(30'000, 100'000, 3);
+	//runTest(100'000, 100'000, 5);
+	//runTest(10'000, 1'000'000, 1'000);
+	//runTest(100'000, 1'000'000, 1'000);
+}

--- a/src/exceptions/ComponentNotRegisteredException.hpp
+++ b/src/exceptions/ComponentNotRegisteredException.hpp
@@ -1,0 +1,23 @@
+#pragma once
+
+#include <iostream>
+#include <string>
+#include <sstream>
+#include <exception>
+
+struct ComponentNotRegisteredException : public std::exception
+{
+public:
+	ComponentNotRegisteredException(std::string componentName) : componentNotRegistered(componentName) {}
+	
+	const char* what() const throw()
+	{
+		std::stringstream ss;
+		ss << this->componentNotRegistered << " must be registered before being used." << std::endl;
+		
+		return ss.str().c_str();
+	}
+
+private:
+	std::string componentNotRegistered;
+};

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -42,7 +42,7 @@ int main()
 
     for (auto entity : ecs.EntitiesWith(Health{}))
     {
-        std::cout << "entity with health: " << entity << std::endl;
+        std::cout << "entity with health: " << entity->UUID << std::endl;
     }
     
 	return 0;

--- a/src/manager_tests.cpp
+++ b/src/manager_tests.cpp
@@ -1,7 +1,9 @@
+#include <string>
+
 #include "doctest.h"
 
 #include "Manager.hpp"
-#include <string>
+#include "exceptions/ComponentNotRegisteredException.hpp"
 
 struct Identity
 {
@@ -12,6 +14,11 @@ struct Health
 {
 	int max;
 	int current;
+};
+
+struct AI
+{
+	std::string difficulty;
 };
 
 TEST_CASE("manager REGISTER")
@@ -96,4 +103,34 @@ TEST_CASE("Manager Happy Path")
 	REQUIRE(storedHp != nullptr);
 	REQUIRE(storedHp->current == hp.current);
 	REQUIRE(storedHp->max == hp.max);
+}
+
+TEST_CASE("Manager AddComponent with unregistered component throws")
+{
+	ECS ecs;
+	Entity e = ecs.CreateEntity();
+
+	CHECK_THROWS_AS(ecs.AddComponent(e, Health()), const ComponentNotRegisteredException);
+}
+
+TEST_CASE("Manager GetComponent with unregistered component throws")
+{
+	ECS ecs;
+	Entity e = ecs.CreateEntity();
+
+	CHECK_THROWS_AS(ecs.GetComponent(e, Health()), const ComponentNotRegisteredException);
+}
+
+TEST_CASE("Manager Entities_With with unregistered component throws")
+{
+	ECS ecs;
+
+	ecs.RegisterComponent(Health());
+	ecs.RegisterComponent(Identity());
+
+	Entity e = ecs.CreateEntity();
+
+	// Should throw because AI is not registered
+	// However, it doesn't throw at all because it only "sees" health in EntitiesWith - after all the recursion.
+	CHECK_THROWS_AS(ecs.EntitiesWith(Health{}, Identity{}, AI{}), const ComponentNotRegisteredException);
 }

--- a/src/manager_tests.cpp
+++ b/src/manager_tests.cpp
@@ -33,58 +33,58 @@ TEST_CASE("manager CREATE")
 	Entity e4 = ecs.CreateEntity();
 
 	// e0 will equal 0 and fail the null check.
-	REQUIRE(e1 != NULL);
-	REQUIRE(e2 != NULL);
-	REQUIRE(e3 != NULL);
-	REQUIRE(e4 != NULL);
+	//REQUIRE(e1 != NULL);
+	//REQUIRE(e2 != NULL);
+	//REQUIRE(e3 != NULL);
+	//REQUIRE(e4 != NULL);
 }
 
 TEST_CASE("Manager ENTITIES WITH")
 {
-	ECS ecs;
+	//ECS ecs;
 
-	ecs.RegisterComponent(Identity());
-	ecs.RegisterComponent(Health());
+	//ecs.RegisterComponent(Identity());
+	//ecs.RegisterComponent(Health());
 
-    // set up entity 1
-	Entity entity1 = ecs.CreateEntity();
+ //   // set up entity 1
+	//Entity entity1 = ecs.CreateEntity();
 
-    Identity ident{ "babs1" };
-    ecs.AddComponent(entity1, ident);
+ //   Identity ident{ "babs1" };
+ //   ecs.AddComponent(entity1, ident);
 
-	Health hp1{ 100, 44 };
-	ecs.AddComponent(entity1, hp1);
+	//Health hp1{ 100, 44 };
+	//ecs.AddComponent(entity1, hp1);
 
-    // set up entity 2
-	Entity entity2 = ecs.CreateEntity();
-    Health hp2{ 50, 22 };
-	ecs.AddComponent(entity2, hp2);
+ //   // set up entity 2
+	//Entity entity2 = ecs.CreateEntity();
+ //   Health hp2{ 50, 22 };
+	//ecs.AddComponent(entity2, hp2);
 
-    // set up entity 3
-    Entity entity3 = ecs.CreateEntity();
+ //   // set up entity 3
+ //   Entity entity3 = ecs.CreateEntity();
 
-    // run a couple searches based on the above entities
-    REQUIRE(ecs.EntitiesWith(Identity{}).size() == 1);
-    REQUIRE(ecs.EntitiesWith(Health{}).size() == 2);
-    REQUIRE(ecs.EntitiesWith().size() == 3);
+ //   // run a couple searches based on the above entities
+ //   REQUIRE(ecs.EntitiesWith(Identity{}).size() == 1);
+ //   REQUIRE(ecs.EntitiesWith(Health{}).size() == 2);
+ //   REQUIRE(ecs.EntitiesWith().size() == 3);
 }
 
 TEST_CASE("Manager Happy Path")
 {
-	ECS ecs;
+	//ECS ecs;
 
-	ecs.RegisterComponent(Identity());
-	ecs.RegisterComponent(Health());
+	//ecs.RegisterComponent(Identity());
+	//ecs.RegisterComponent(Health());
 
-	Entity entity1 = ecs.CreateEntity();
+	//Entity entity1 = ecs.CreateEntity();
 
-	Health hp{ 100, 44 };
-	ecs.AddComponent(entity1, hp);
+	//Health hp{ 100, 44 };
+	//ecs.AddComponent(entity1, hp);
 
-	// Getting component
-	Health* storedHp = ecs.GetComponent(entity1, Health());
-	
-	REQUIRE(storedHp != nullptr);
-	REQUIRE(storedHp->current == hp.current);
-	REQUIRE(storedHp->max == hp.max);
+	//// Getting component
+	//Health* storedHp = ecs.GetComponent(entity1, Health());
+	//
+	//REQUIRE(storedHp != nullptr);
+	//REQUIRE(storedHp->current == hp.current);
+	//REQUIRE(storedHp->max == hp.max);
 }

--- a/src/manager_tests.cpp
+++ b/src/manager_tests.cpp
@@ -32,59 +32,68 @@ TEST_CASE("manager CREATE")
 	Entity e3 = ecs.CreateEntity();
 	Entity e4 = ecs.CreateEntity();
 
-	// e0 will equal 0 and fail the null check.
-	//REQUIRE(e1 != NULL);
-	//REQUIRE(e2 != NULL);
-	//REQUIRE(e3 != NULL);
-	//REQUIRE(e4 != NULL);
+	REQUIRE(e0.bitfield == 0);
+	REQUIRE(e0.UUID == 0);
+
+	REQUIRE(e1.bitfield == 0);
+	REQUIRE(e1.UUID == 1);
+
+	REQUIRE(e2.bitfield == 0);
+	REQUIRE(e2.UUID == 2);
+
+	REQUIRE(e3.bitfield == 0);
+	REQUIRE(e3.UUID == 3);
+
+	REQUIRE(e4.bitfield == 0);
+	REQUIRE(e4.UUID == 4);
 }
 
 TEST_CASE("Manager ENTITIES WITH")
 {
-	//ECS ecs;
+	ECS ecs;
 
-	//ecs.RegisterComponent(Identity());
-	//ecs.RegisterComponent(Health());
+	ecs.RegisterComponent(Identity());
+	ecs.RegisterComponent(Health());
 
- //   // set up entity 1
-	//Entity entity1 = ecs.CreateEntity();
+    // set up entity 1
+	Entity entity1 = ecs.CreateEntity();
 
- //   Identity ident{ "babs1" };
- //   ecs.AddComponent(entity1, ident);
+    Identity ident{ "babs1" };
+    ecs.AddComponent(entity1, ident);
 
-	//Health hp1{ 100, 44 };
-	//ecs.AddComponent(entity1, hp1);
+	Health hp1{ 100, 44 };
+	ecs.AddComponent(entity1, hp1);
 
- //   // set up entity 2
-	//Entity entity2 = ecs.CreateEntity();
- //   Health hp2{ 50, 22 };
-	//ecs.AddComponent(entity2, hp2);
+    // set up entity 2
+	Entity entity2 = ecs.CreateEntity();
+    Health hp2{ 50, 22 };
+	ecs.AddComponent(entity2, hp2);
 
- //   // set up entity 3
- //   Entity entity3 = ecs.CreateEntity();
+    // set up entity 3
+    Entity entity3 = ecs.CreateEntity();
 
- //   // run a couple searches based on the above entities
- //   REQUIRE(ecs.EntitiesWith(Identity{}).size() == 1);
- //   REQUIRE(ecs.EntitiesWith(Health{}).size() == 2);
- //   REQUIRE(ecs.EntitiesWith().size() == 3);
+    // run a couple searches based on the above entities
+    REQUIRE(ecs.EntitiesWith(Identity{}).size() == 1);
+    REQUIRE(ecs.EntitiesWith(Health{}).size() == 2);
+    REQUIRE(ecs.EntitiesWith().size() == 3);
 }
 
 TEST_CASE("Manager Happy Path")
 {
-	//ECS ecs;
+	ECS ecs;
 
-	//ecs.RegisterComponent(Identity());
-	//ecs.RegisterComponent(Health());
+	ecs.RegisterComponent(Identity());
+	ecs.RegisterComponent(Health());
 
-	//Entity entity1 = ecs.CreateEntity();
+	Entity entity1 = ecs.CreateEntity();
 
-	//Health hp{ 100, 44 };
-	//ecs.AddComponent(entity1, hp);
+	Health hp{ 100, 44 };
+	ecs.AddComponent(entity1, hp);
 
-	//// Getting component
-	//Health* storedHp = ecs.GetComponent(entity1, Health());
-	//
-	//REQUIRE(storedHp != nullptr);
-	//REQUIRE(storedHp->current == hp.current);
-	//REQUIRE(storedHp->max == hp.max);
+	// Getting component
+	Health* storedHp = ecs.GetComponent(entity1, Health());
+	
+	REQUIRE(storedHp != nullptr);
+	REQUIRE(storedHp->current == hp.current);
+	REQUIRE(storedHp->max == hp.max);
 }


### PR DESCRIPTION
### **Merge #8  before reviewing this one**
_This PR was branched off of #8 and any changes to #8 will need to reflect over to this branch_


Closes #4 


Adds a custom exception to be thrown when an unregistered component is attempted to be used in the following cases:

- AddComponent
- GetComponent
- EntitiesWith

If an unregistered component is passed into either of these functions, an exception of type `ComponentNotRegisteredException` will be thrown. The error message in the exception is:

>$ComponentName must be registered before being used.