### PR TITLE
Exceptions to stop segfaults

### DIFF
--- a/src/Manager.hpp
+++ b/src/Manager.hpp
@@ -9,6 +9,7 @@
 #include <typeinfo>
 #include <vector>
 
+#include "exceptions/ComponentNotRegisteredException.hpp"
 
 struct Entity
 {

--- a/src/Manager.hpp
+++ b/src/Manager.hpp
@@ -95,6 +95,19 @@ private:
 
 	template <typename T, typename ...Ts>
 	std::vector<std::string> GetComponentNames(std::vector<std::string> names, T type, Ts... types);
+
+	bool ComponentIsRegistered(std::string componentName)
+	{
+		for (auto const& component : this->components)
+		{
+			if (component.first == componentName)
+			{
+				return true;
+			}
+		}
+
+		return false;
+	}
 };
 
 template<typename T>
@@ -122,6 +135,12 @@ template<typename T>
 inline void ECS::AddComponent(Entity entity, T component)
 {
 	std::string componentName = this->GetComponentName(component);
+
+	if (!this->ComponentIsRegistered(componentName))
+	{
+		throw ComponentNotRegisteredException(componentName);
+	}
+
 	ComponentContainer<T>* container = dynamic_cast<ComponentContainer<T>*>(this->components[componentName]);
 	container->data[entity] = component;
 	int componentFlag = componentIndex[componentName];
@@ -148,6 +167,11 @@ template<typename T>
 inline T* ECS::GetComponent(Entity entity, T component)
 {
 	std::string componentName = this->GetComponentName(component);
+	if (!this->ComponentIsRegistered(componentName))
+	{
+		throw ComponentNotRegisteredException(componentName);
+	}
+
 	int componentFlag = componentIndex[componentName];
 	
 	for (Entity e : this->entities)
@@ -185,12 +209,8 @@ std::vector<std::string> ECS::GetComponentNames(std::vector<std::string> names, 
 	std::string name = this->GetComponentName(std::forward<T>(type));
 	names.push_back(name);
 
-	// recursion basically - we keep showing up in this function, and eventually
-	// we hit the base case of one type and no list of types, so we get sent to the
-	// function above and then everything returns back to the caller.
-	this->GetComponentNames(names, std::forward<Ts>(types)...);
-
-	return names;
+	// Continue getting component neames until we are out of template arguments and return the list
+	return this->GetComponentNames(names, std::forward<Ts>(types)...);
 }
 
 template<typename ...Ts>
@@ -199,6 +219,14 @@ inline std::vector<Entity*> ECS::EntitiesWith(Ts&& ...types)
 	// build bitfield flags for this search
 	std::vector<std::string> componentNames;
 	componentNames = this->GetComponentNames(componentNames, std::forward<Ts>(types)...);
+
+	for (auto componentName : componentNames)
+	{
+		if (!this->ComponentIsRegistered(componentName))
+		{
+			throw ComponentNotRegisteredException(componentName);
+		}
+	}
 
 	bitfield::Bitfield field = 0;
 	for (auto name : componentNames)

--- a/src/exceptions/ComponentNotRegisteredException.hpp
+++ b/src/exceptions/ComponentNotRegisteredException.hpp
@@ -1,0 +1,23 @@
+#pragma once
+
+#include <iostream>
+#include <string>
+#include <sstream>
+#include <exception>
+
+struct ComponentNotRegisteredException : public std::exception
+{
+public:
+	ComponentNotRegisteredException(std::string componentName) : componentNotRegistered(componentName) {}
+
+	const char* what() const throw()
+	{
+		std::stringstream ss;
+		ss << this->componentNotRegistered << " must be registered before being used." << std::endl;
+
+		return ss.str().c_str();
+	}
+
+private:
+	std::string componentNotRegistered;
+};

--- a/src/exceptions/ComponentNotRegisteredException.hpp
+++ b/src/exceptions/ComponentNotRegisteredException.hpp
@@ -8,14 +8,9 @@
 struct ComponentNotRegisteredException : public std::exception
 {
 public:
-	ComponentNotRegisteredException(std::string componentName) : componentNotRegistered(componentName) {}
-
-	const char* what() const throw()
+	ComponentNotRegisteredException(std::string componentName) : componentNotRegistered(componentName) 
 	{
-		std::stringstream ss;
-		ss << this->componentNotRegistered << " must be registered before being used." << std::endl;
-
-		return ss.str().c_str();
+		std::cerr << this->componentNotRegistered << " must be registered before being used." << std::endl;
 	}
 
 private:

--- a/src/manager_tests.cpp
+++ b/src/manager_tests.cpp
@@ -1,11 +1,18 @@
 #include "doctest.h"
 
-#include "Manager.hpp"
 #include <string>
+
+#include "Manager.hpp"
+#include "exceptions/ComponentNotRegisteredException.hpp"
 
 struct Identity
 {
 	std::string name;
+};
+
+struct AI
+{
+	std::string difficulty;
 };
 
 struct Health
@@ -96,4 +103,34 @@ TEST_CASE("Manager Happy Path")
 	REQUIRE(storedHp != nullptr);
 	REQUIRE(storedHp->current == hp.current);
 	REQUIRE(storedHp->max == hp.max);
+}
+
+TEST_CASE("Manager AddComponent with unregistered component throws")
+{
+	ECS ecs;
+	Entity e = ecs.CreateEntity();
+
+	CHECK_THROWS_AS(ecs.AddComponent(e, Health()), const ComponentNotRegisteredException);
+}
+
+TEST_CASE("Manager GetComponent with unregistered component throws")
+{
+	ECS ecs;
+	Entity e = ecs.CreateEntity();
+
+	CHECK_THROWS_AS(ecs.GetComponent(e, Health()), const ComponentNotRegisteredException);
+}
+
+TEST_CASE("Manager Entities_With with unregistered component throws")
+{
+	ECS ecs;
+
+	ecs.RegisterComponent(Health());
+	ecs.RegisterComponent(Identity());
+
+	Entity e = ecs.CreateEntity();
+
+	// Should throw because AI is not registered
+	// However, it doesn't throw at all because it only "sees" health in EntitiesWith - after all the recursion.
+	CHECK_THROWS_AS(ecs.EntitiesWith(Health{}, Identity{}, AI{}), const ComponentNotRegisteredException);
 }


### PR DESCRIPTION
Closes #4

Adds a custom exception to be thrown when an unregistered component is attempted to be used in the following cases:

- AddComponent
- GetComponent
- EntitiesWith

If an unregistered component is passed into either of these functions, an exception of type `ComponentNotRegisteredException` will be thrown. The error message in the exception is:

> $ComponentName must be registered before being used.

Additionally fixes a bug with EntitiesWith(...) not using recursion and returning 1 element vector.


