### PR TITLE
Feature/component specific lists

### DIFF
--- a/src/Manager.hpp
+++ b/src/Manager.hpp
@@ -195,7 +195,7 @@ inline T* ECS::GetComponent(Entity entity, T component)
 		}
 	}
 
-	return NULL;
+	return nullptr;
 }
 
 std::vector<std::string>* ECS::GetComponentNames(std::vector<std::string>* names)

--- a/src/Manager.hpp
+++ b/src/Manager.hpp
@@ -257,7 +257,7 @@ inline std::vector<Entity*> ECS::EntitiesWith(Ts&& ...types)
 		}
 
 		auto vec = &this->individualComponentVecs[componentName];
-		componentListSizes.push_back({ componentName, vec->size() });
+		componentListSizes.push_back(std::make_tuple(componentName, vec->size()));
 	}
 
 	bitfield::Bitfield field = 0;

--- a/src/Manager.hpp
+++ b/src/Manager.hpp
@@ -92,25 +92,17 @@ private:
 	template <typename T>
 	std::string GetComponentName(T component);
 
-	std::vector<std::string> GetComponentNames(std::vector<std::string> names);
+	std::vector<std::string>* GetComponentNames(std::vector<std::string>* names);
 
 	template <typename T>
-	std::vector<std::string> GetComponentNames(std::vector<std::string> names, T type);
+	std::vector<std::string>* GetComponentNames(std::vector<std::string>* names, T type);
 
 	template <typename T, typename ...Ts>
-	std::vector<std::string> GetComponentNames(std::vector<std::string> names, T type, Ts... types);
+	std::vector<std::string>* GetComponentNames(std::vector<std::string>* names, T type, Ts... types);
 
 	bool ComponentIsRegistered(std::string componentName)
 	{
-		for (auto const& component : this->components)
-		{
-			if (component.first == componentName)
-			{
-				return true;
-			}
-		}
-
-		return false;
+		return (this->components.count(componentName) > 0);
 	}
 };
 
@@ -206,25 +198,25 @@ inline T* ECS::GetComponent(Entity entity, T component)
 	return NULL;
 }
 
-std::vector<std::string> ECS::GetComponentNames(std::vector<std::string> names)
+std::vector<std::string>* ECS::GetComponentNames(std::vector<std::string>* names)
 {
 	return names;
 }
 
 template <typename T>
-std::vector<std::string> ECS::GetComponentNames(std::vector<std::string> names, T type)
+std::vector<std::string>* ECS::GetComponentNames(std::vector<std::string>* names, T type)
 {
 	std::string name = this->GetComponentName(std::forward<T>(type));
-	names.push_back(name);
+	names->push_back(name);
 
 	return names;
 }
 
 template <typename T, typename ...Ts>
-std::vector<std::string> ECS::GetComponentNames(std::vector<std::string> names, T type, Ts... types)
+std::vector<std::string>* ECS::GetComponentNames(std::vector<std::string>* names, T type, Ts... types)
 {
 	std::string name = this->GetComponentName(std::forward<T>(type));
-	names.push_back(name);
+	names->push_back(name);
 
 	// Continue getting component neames until we are out of template arguments and return the list
 	return this->GetComponentNames(names, std::forward<Ts>(types)...);
@@ -235,7 +227,7 @@ inline std::vector<Entity*> ECS::EntitiesWith(Ts&& ...types)
 {
 	// build bitfield flags for this search
 	std::vector<std::string> componentNames;
-	componentNames = this->GetComponentNames(componentNames, std::forward<Ts>(types)...);
+	this->GetComponentNames(&componentNames, std::forward<Ts>(types)...);
 	
 	if (componentNames.size() == 0)
 	{

--- a/src/Manager.hpp
+++ b/src/Manager.hpp
@@ -161,7 +161,6 @@ inline void ECS::AddComponent(Entity entity, T component)
 				std::vector<Entity> entityList;
 				entityList.push_back(e);
 				this->individualComponentVecs.insert(std::pair<std::string, std::vector<Entity>>(componentName, entityList));
-				//this->individualComponentVecs.insert(std::make_pair(componentName, e));
 			}
 		}
 	}

--- a/src/Manager.hpp
+++ b/src/Manager.hpp
@@ -236,6 +236,17 @@ inline std::vector<Entity*> ECS::EntitiesWith(Ts&& ...types)
 	// build bitfield flags for this search
 	std::vector<std::string> componentNames;
 	componentNames = this->GetComponentNames(componentNames, std::forward<Ts>(types)...);
+	
+	if (componentNames.size() == 0)
+	{
+		// Asking for all entities
+		std::vector<Entity*> requestedEntities;
+		for (auto e : this->entities)
+		{
+			requestedEntities.push_back(&e);
+		}
+		return requestedEntities;
+	}
 
 	std::vector<std::tuple<std::string, int>> componentListSizes;
 	for (auto componentName : componentNames)

--- a/src/Manager.hpp
+++ b/src/Manager.hpp
@@ -85,6 +85,8 @@ private:
 	std::map<std::string, BaseContainer*> components;
 	std::map<std::string, bitfield::Bitfield> componentIndex;
 
+	std::map<std::string, std::vector<Entity>> individualComponentVecs;
+
 	template <typename T>
 	std::string GetComponentName(T component);
 
@@ -135,6 +137,19 @@ inline void ECS::AddComponent(Entity entity, T component)
 		{
 			entityFound = true;
 			e.bitfield = bitfield::Set(e.bitfield, componentFlag);
+
+			auto iter = this->individualComponentVecs.find(componentName);
+			if (iter != this->individualComponentVecs.end())
+			{
+				iter->second.push_back(e);
+			}
+			else
+			{
+				std::vector<Entity> entityList;
+				entityList.push_back(e);
+				this->individualComponentVecs.insert(std::pair<std::string, std::vector<Entity>>(componentName, entityList));
+				//this->individualComponentVecs.insert(std::make_pair(componentName, e));
+			}
 		}
 	}
 
@@ -142,6 +157,8 @@ inline void ECS::AddComponent(Entity entity, T component)
 	{
 		throw std::runtime_error("Failed to find entity to add component to");
 	}
+
+
 }
 
 template<typename T>
@@ -188,9 +205,7 @@ std::vector<std::string> ECS::GetComponentNames(std::vector<std::string> names, 
 	// recursion basically - we keep showing up in this function, and eventually
 	// we hit the base case of one type and no list of types, so we get sent to the
 	// function above and then everything returns back to the caller.
-	this->GetComponentNames(names, std::forward<Ts>(types)...);
-
-	return names;
+	return this->GetComponentNames(names, std::forward<Ts>(types)...);
 }
 
 template<typename ...Ts>

--- a/src/Manager.hpp
+++ b/src/Manager.hpp
@@ -255,7 +255,7 @@ inline std::vector<Entity*> ECS::EntitiesWith(Ts&& ...types)
 		field = bitfield::Set(field, this->componentIndex[name]);
 	}
 
-	std::string smallestComponentList = std::get<0>(*std::min_element(begin(requestedListAndSize), end(requestedListAndSize), [](auto lhs, auto rhs) {return std::get<1>(lhs) < std::get<1>(rhs); }));
+	std::string smallestComponentList = std::get<0>(*std::min_element(begin(componentListSizes), end(componentListSizes), [](auto lhs, auto rhs) {return std::get<1>(lhs) < std::get<1>(rhs); }));
 	auto entitySearchVector = this->individualComponentVecs[smallestComponentList];
 
 	std::vector<Entity*> requestedEntities;

--- a/src/benchmark.cpp
+++ b/src/benchmark.cpp
@@ -87,11 +87,11 @@ void runTest(int entityCount, int iterationCount, int tagProb) {
 int main() {
 	std::cout << "Running benchmark..." << std::endl << std::endl;
 	printHeader();
-	runTest(1'000, 1'000'000, 3);
-	runTest(10'000, 1'000'000, 3);
-	runTest(30'000, 100'000, 3);
-	runTest(100'000, 100'000, 5);
-	runTest(10'000, 1'000'000, 1'000);
-	runTest(100'000, 1'000'000, 1'000);
+	runTest(1'000, 100'000, 3);
+	runTest(10'000, 100'000, 3);
+	runTest(30'000, 10'000, 3);
+	runTest(100'000, 10'000, 5);
+	runTest(10'000, 100'000, 1'000);
+	runTest(100'000, 100'000, 1'000);
 	printFooter();
 }

--- a/src/benchmark.cpp
+++ b/src/benchmark.cpp
@@ -31,7 +31,7 @@ void printHeader()
 
 void printResults(std::string name, int entities, int iterations, int probability, std::chrono::milliseconds duration)
 {
-	std::cout << "|" << name << "\t" << entities << "\t\t" << iterations << "\t\t\t" << "1/" <<probability << "\t\t\t" << duration.count() << "\t\t  |" << std::endl;
+	std::cout << "|" << name << "\t\t" << entities << "\t\t" << iterations << "\t\t\t" << "1/" <<probability << "\t\t\t" << duration.count() << "\t\t  |" << std::endl;
 }
 
 void printFooter()
@@ -67,17 +67,16 @@ void babsEcsTest(int entityCount, int iterationCount, int tagProb)
 	{
 		Timer timer;
 
-		std::uint64_t sum = 0;
-		for (int i = 0; i < iterationCount; ++i) {
-			auto entities = ecs.EntitiesWith(Identity{});
-			for (auto entity : entities)
-			{
-				sum++;
-			}
-		}
-		timer.End();
-		printResults("entities w / Identity", entityCount, iterationCount, tagProb, timer.elapsed);
-
+        std::uint64_t sum = 0;
+        for (int i = 0; i < iterationCount; ++i) {
+            auto entities = ecs.EntitiesWith(Identity{}, Tag{});
+            for (auto entity : entities)
+            {
+                sum++;
+            }
+        }
+        timer.End();
+        printResults("Identity + Tag", entityCount, iterationCount, tagProb, timer.elapsed);
 	}
 }
 


### PR DESCRIPTION
Closes #7 

Adds component specific lists that greatly reduce the search time for entities with rare components added to them.

Example:

- 1000 Entities
  - 900 with Identity
  - 100 with AI

Using `EntitiesWith(Identity(), AI());` we do NOT search the entire entity list anymore (1,000 entries). We detect that the smallest component being requested is `AI` and start there - narrowing the search down to 100.

Some other various modifications and improvements on performance were made as well:

- Component Names via recursion in EntitiesWith is switched to pass a pointer to the vector of names instead of reference
- Checking the map if a component is registered at all is moved off an iterative approach to a quick 'count' check.
- Benchmark has been reworked to actually be correct now
