### PR TITLE
Remove components from entities

### DIFF
--- a/src/Manager.hpp
+++ b/src/Manager.hpp
@@ -194,17 +194,24 @@ inline void ECS::RemoveComponent(Entity entity, T component)
 			entityFound = true;
 			e.bitfield = bitfield::Clear(e.bitfield, componentFlag);
 
-			auto iter = this->individualComponentVecs.find(componentName);
-			if (iter != this->individualComponentVecs.end())
+			auto componentVector = this->individualComponentVecs.find(componentName);
+			
+			for (std::vector<Entity>::iterator it = componentVector->second.begin(); it != componentVector->second.end(); ++it)
 			{
-				this->individualComponentVecs.erase(iter->first);
+				if (it->UUID == e.UUID)
+				{
+					componentVector->second.erase(it);
+					break;
+				}
 			}
+
+			break;
 		}
 	}
 
 	if (!entityFound)
 	{
-		throw std::runtime_error("Failed to find entity to add component to");
+		throw std::runtime_error("Failed to find entity to remove component from");
 	}
 }
 

--- a/src/Manager.hpp
+++ b/src/Manager.hpp
@@ -75,6 +75,9 @@ public:
 	void AddComponent(Entity entity, T component);
 
 	template <typename T>
+	void RemoveComponent(Entity entity, T component);
+
+	template <typename T>
 	T* GetComponent(Entity entity, T component);
 
 	template<typename... Ts>
@@ -161,6 +164,40 @@ inline void ECS::AddComponent(Entity entity, T component)
 				std::vector<Entity> entityList;
 				entityList.push_back(e);
 				this->individualComponentVecs.insert(std::pair<std::string, std::vector<Entity>>(componentName, entityList));
+			}
+		}
+	}
+
+	if (!entityFound)
+	{
+		throw std::runtime_error("Failed to find entity to add component to");
+	}
+}
+
+template<typename T>
+inline void ECS::RemoveComponent(Entity entity, T component)
+{
+	std::string componentName = this->GetComponentName(component);
+
+	if (!this->ComponentIsRegistered(componentName))
+	{
+		throw ComponentNotRegisteredException(componentName);
+	}
+
+	int componentFlag = componentIndex[componentName];
+
+	bool entityFound = false;
+	for (Entity& e : this->entities)
+	{
+		if (e.UUID == entity.UUID)
+		{
+			entityFound = true;
+			e.bitfield = bitfield::Clear(e.bitfield, componentFlag);
+
+			auto iter = this->individualComponentVecs.find(componentName);
+			if (iter != this->individualComponentVecs.end())
+			{
+				this->individualComponentVecs.erase(iter->first);
 			}
 		}
 	}

--- a/src/manager_tests.cpp
+++ b/src/manager_tests.cpp
@@ -145,14 +145,24 @@ TEST_CASE("manager REMOVE COMPONENT")
 	Identity e0Ident = Identity();
 	e0Ident.name = "babs2";
 
+	Identity e1Ident = Identity();
+	e1Ident.name = "babs1";
+
 	Health e0Health = Health();
 	e0Health.current = 100;
 	e0Health.max = 100;
 
-	Entity e0 = ecs.CreateEntity();
+	Health e1Health = Health();
+	e1Health.current = 90;
+	e1Health.max = 90;
 
+	Entity e0 = ecs.CreateEntity();
+	Entity e1 = ecs.CreateEntity();
 	ecs.AddComponent(e0, e0Ident);
 	ecs.AddComponent(e0, e0Health);
+
+	ecs.AddComponent(e1, e1Ident);
+	ecs.AddComponent(e1, e1Health);
 
 	// has Health
 	auto health = ecs.GetComponent(e0, Health());
@@ -169,4 +179,8 @@ TEST_CASE("manager REMOVE COMPONENT")
 	//still has Identity
 	auto identity = ecs.GetComponent(e0, Identity());
 	REQUIRE(identity->name == "babs2");
+	
+	auto entitiesWithHealth = ecs.EntitiesWith(Health());
+
+	REQUIRE(entitiesWithHealth.size() == 1);
 }

--- a/src/manager_tests.cpp
+++ b/src/manager_tests.cpp
@@ -134,3 +134,39 @@ TEST_CASE("Manager Entities_With with unregistered component throws")
 	// However, it doesn't throw at all because it only "sees" health in EntitiesWith - after all the recursion.
 	CHECK_THROWS_AS(ecs.EntitiesWith(Health{}, Identity{}, AI{}), const ComponentNotRegisteredException);
 }
+
+TEST_CASE("manager REMOVE COMPONENT")
+{
+	ECS ecs;
+
+	ecs.RegisterComponent(Identity());
+	ecs.RegisterComponent(Health());
+
+	Identity e0Ident = Identity();
+	e0Ident.name = "babs2";
+
+	Health e0Health = Health();
+	e0Health.current = 100;
+	e0Health.max = 100;
+
+	Entity e0 = ecs.CreateEntity();
+
+	ecs.AddComponent(e0, e0Ident);
+	ecs.AddComponent(e0, e0Health);
+
+	// has Health
+	auto health = ecs.GetComponent(e0, Health());
+	REQUIRE(e0Health.current == health->current);
+	REQUIRE(e0Health.max == health->max);
+
+	ecs.RemoveComponent(e0, Health());
+
+	// does not have health anymore
+	auto noHealth = ecs.GetComponent(e0, Health());
+
+	REQUIRE(noHealth == nullptr);
+
+	//still has Identity
+	auto identity = ecs.GetComponent(e0, Identity());
+	REQUIRE(identity->name == "babs2");
+}


### PR DESCRIPTION
Adds a remove function to the ECS manager to allow removal of components on entities.

Also updates the individual component vector during the removal

Added light unit test to prove functionality (file will undergo big changes soon)