### PR TITLE
Feature/simplified component args

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,7 +91,7 @@ ecs.RemoveComponent<Identity>(player);
 
 ### Searching
 
-Now for the meat and potatoes of searching through ECS! When querying ECS, you will be returned a vector of Entity's:
+Now for the meat and potatoes of searching through ECS! When querying ECS, you will be returned a vector of entities:
 
 ```c++
 for (babs_ecs::Entity entity : ecs.EntitiesWith<Identity>())

--- a/README.md
+++ b/README.md
@@ -52,15 +52,15 @@ babs_ecs::ECSManager ecs;
 
 ### Entities
 
-Entities are easy to create and effectively just a unique identifier within the manager. It's safe to store the entities in your own systems, but make sure to go through the manager when checking the latest component availability.
+Entities are easy to create and effectively just a unique identifier within the manager. It's safe to store the entities in your own systems, but make sure to go through the manager when checking the latest component availability. A `babs_ecs::EntityNotFoundException` will be thrown if a removed or invalid Entity is used.
 
 ```c++
-#include "babs-ecs/ECS.hpp"
-
-babs_ecs::ECSManager ecs;
-
 babs_ecs::Entity entity = ecs.CreateEntity();
 entity.UUID // returns 0 since it's the first
+
+ecs.RemoveEntity();
+entity = ecs.CreateEntity();
+entity.UUID // returns 0 again as ECS will reclaim UUIDs
 ```
 
 ### Components
@@ -68,15 +68,9 @@ entity.UUID // returns 0 since it's the first
 Components can be defined freely and registered with ECS for subsequent use. They can be as complicated as you need, so feel free to add methods.
 
 ```c++
-#include <string>
-#include <iostream>
-#include "babs-ecs/ECS.hpp"
-
 struct Identity {
     std::string name;
 };
-
-babs_ecs::ECSManager ecs;
 
 ecs.RegisterComponent<Identity>();
 ```
@@ -95,14 +89,27 @@ std::cout << "players name is " << ident.name << std::endl;
 ecs.RemoveComponent<Identity>(player);
 ```
 
+### Searching
+
+Now for the meat and potatoes of searching through ECS! When querying ECS, you will be returned a vector of Entity's:
+
+```c++
+for (babs_ecs::Entity entity : ecs.EntitiesWith<Identity>())
+{
+    Identity* identity = ecs.GetComponent<Identity>(entity);
+    std::cout << "entity " << entity.UUID << " is named " << identity.name << std::endl;
+}
+```
+
+The `EntitiesWith` function can be called with 0+ component types. `EntitiesWith()` will return all entities in ECS, whereas `EntitiesWith<Identity, Health>()` will only return entities with both Identity and Health components.
+
+Tip: When possible, include the most uncommon component type that still returns all the desired entities for a particular search. This can result in searches that are multiple orders of mangitude faster!
+
 ### Events
 
 Event systems work well with ECS for de-coupled communication between systems. Events are as easy as components to work with. These don't require registration, and you can subscribe and broadcast at any time through the event manager provided by the ECS instance.
 
 ```c++
-#include "babs-ecs/ECS.hpp"
-
-babs_ecs::ECSManager ecs;
 
 struct CollisionEvent
 {

--- a/README.md
+++ b/README.md
@@ -78,7 +78,7 @@ struct Identity {
 
 babs_ecs::ECSManager ecs;
 
-ecs.RegisterComponent(Identity());
+ecs.RegisterComponent<Identity>();
 ```
 
 Once the component is registered, instances of it can be assigned to specific entities, retrieved later, and removed. An exception will be thrown if you try to access or remove component data that doesn't exist.
@@ -89,10 +89,10 @@ Identity player_identity{"babs"};
 
 ecs.AddComponent(player, player_identity);
 
-Identity ident = ecs.GetComponent(Identity());
+Identity ident = ecs.GetComponent<Identity>();
 std::cout << "players name is " << ident.name << std::endl;
 
-ecs.RemoveComponent(player, Identity());
+ecs.RemoveComponent<Identity>(player);
 ```
 
 ### Events

--- a/src/ECSManager.hpp
+++ b/src/ECSManager.hpp
@@ -85,22 +85,22 @@ namespace babs_ecs
         }
 
         template <typename T>
-        void RegisterComponent(T component);
+        void RegisterComponent();
 
         template <typename T>
         void AddComponent(Entity entity, T component);
 
         template <typename T>
-        void RemoveComponent(Entity entity, T component);
+        void RemoveComponent(Entity entity);
 
         template <typename T>
-        T* GetComponent(Entity entity, T component);
+        T* GetComponent(Entity entity);
 
         template<typename... Ts>
         std::vector<Entity> EntitiesWith(Ts&& ... types);
 
         template <typename T>
-        bool HasComponent(Entity entity, T component);
+        bool HasComponent(Entity entity);
 
         void RemoveEntity(Entity entity)
         {
@@ -147,6 +147,9 @@ namespace babs_ecs
         template <typename T>
         std::string GetComponentName(T component);
 
+        template <typename T>
+        std::string GetComponentName();
+
         std::vector<std::string>* GetComponentNames(std::vector<std::string>* names);
 
         template <typename T>
@@ -165,11 +168,11 @@ namespace babs_ecs
     //
     // Until this is called, components cannot be added/retrieved.
     template<typename T>
-    inline void ECSManager::RegisterComponent(T component)
+    inline void ECSManager::RegisterComponent()
     {
         // Example: "class TestComponent", "struct Health", "struct Identity"
         // using typeid(T).name() means we don't need to rely on ToString();
-        std::string componentName = this->GetComponentName(component);
+        std::string componentName = this->GetComponentName<T>();
 
         if (components.find(componentName) == components.end())
         {
@@ -249,9 +252,9 @@ namespace babs_ecs
 
     // GetComponent will return a pointer to the entities component data. Modifications to the component will persist.
     template<typename T>
-    inline void ECSManager::RemoveComponent(Entity entity, T component)
+    inline void ECSManager::RemoveComponent(Entity entity)
     {
-        std::string componentName = this->GetComponentName(component);
+        std::string componentName = this->GetComponentName<T>();
 
         if (!this->ComponentIsRegistered(componentName))
         {
@@ -317,9 +320,9 @@ namespace babs_ecs
     }
 
     template<typename T>
-    inline T* ECSManager::GetComponent(Entity entity, T component)
+    inline T* ECSManager::GetComponent(Entity entity)
     {
-        std::string componentName = this->GetComponentName(component);
+        std::string componentName = this->GetComponentName<T>();
         if (!this->ComponentIsRegistered(componentName))
         {
             throw babs_ecs::ComponentNotRegisteredException(componentName);
@@ -437,15 +440,21 @@ namespace babs_ecs
     // Returns the compiler created string for this component. We don't actually care what the
     // string is, but generally it seems to match the type name.
     template<typename T>
-    inline bool ECSManager::HasComponent(Entity entity, T component)
+    inline bool ECSManager::HasComponent(Entity entity)
     {
-        return this->GetComponent(entity, component) != nullptr ? true : false;
+        return this->GetComponent<T>(entity) != nullptr ? true : false;
     }
 
     template<typename T>
     inline std::string ECSManager::GetComponentName(T component)
     {
         return typeid(component).name();
+    }
+
+    template<typename T>
+    inline std::string ECSManager::GetComponentName()
+    {
+        return typeid(T).name();
     }
 
 }

--- a/src/ECSManager.hpp
+++ b/src/ECSManager.hpp
@@ -145,13 +145,10 @@ namespace babs_ecs
         std::map<std::string, std::vector<Entity>> individualComponentVecs;
 
         template <typename T>
-        std::string GetComponentName(T component);
-
-        template <typename T>
         std::string GetComponentName();
 
         template <typename T, typename... Ts>
-        std::vector<std::string> HotNewGetComponentNames();
+        std::vector<std::string> GetComponentNames();
 
         bool ComponentIsRegistered(std::string componentName)
         {
@@ -342,18 +339,20 @@ namespace babs_ecs
     }
 
     template<typename T, typename... Ts>
-    inline std::vector<std::string> ECSManager::HotNewGetComponentNames()
+    inline std::vector<std::string> ECSManager::GetComponentNames()
     {
         std::vector<std::string> names;
 
         if constexpr(sizeof...(Ts) == 0)
         {
+            // this is effectively the "base case" if you were to think of this like recursion
             names.push_back(typeid(T).name());
         }
         else
         {
-            names = HotNewGetComponentNames<Ts...>();
-            names.push_back(HotNewGetComponentNames<T>()[0]);
+            // we must still have more component names to retrieve, continue templating
+            names = GetComponentNames<Ts...>();
+            names.push_back(GetComponentNames<T>()[0]);
         }
 
         return names;
@@ -371,7 +370,7 @@ namespace babs_ecs
         std::vector<std::string> componentNames;
         if constexpr(sizeof...(Ts) > 0)
         {
-            componentNames = this->HotNewGetComponentNames<Ts...>();
+            componentNames = this->GetComponentNames<Ts...>();
         }
 
         // if no components were provided, we'll return all entities

--- a/src/ECSManager_tests.cpp
+++ b/src/ECSManager_tests.cpp
@@ -151,14 +151,14 @@ TEST_SUITE("Manager Searching")
 		babs_ecs::Entity entity3 = ecs.CreateEntity();
 
 		// run a couple searches based on the above entities
-		REQUIRE(ecs.EntitiesWith(Identity{}).size() == 1);
-		REQUIRE(ecs.EntitiesWith(Health{}).size() == 2);
+		REQUIRE(ecs.EntitiesWith<Identity>().size() == 1);
+		REQUIRE(ecs.EntitiesWith<Health>().size() == 2);
 		REQUIRE(ecs.EntitiesWith().size() == 3);
 	}
 
 	TEST_CASE("EntitysWith finds 2 entities with Health")
 	{
-		REQUIRE(ecs.EntitiesWith(Health{}).size() == 2);
+		REQUIRE(ecs.EntitiesWith<Health>().size() == 2);
 	}
 
 	TEST_CASE("EntitiesWith finds all entities when no components are specified")
@@ -186,7 +186,7 @@ TEST_SUITE("Manager Searching")
 		babs_ecs::Entity e = ecs.CreateEntity();
 
 		// Should throw because AI is not registered
-		CHECK_THROWS_AS(ecs.EntitiesWith(Health{}, Identity{}, AI{}), const babs_ecs::ComponentNotRegisteredException);
+		CHECK_THROWS_AS(ecs.EntitiesWith<AI>(), const babs_ecs::ComponentNotRegisteredException);
 	}
 
 	TEST_CASE("Manager EntitiesWith - multiple entities")
@@ -206,7 +206,7 @@ TEST_SUITE("Manager Searching")
 		ecs.AddComponent(entity, ident);
 		ecs.AddComponent(entity, hp);
 
-		auto healthAndIdentity = ecs.EntitiesWith(Identity(), Health());
+		auto healthAndIdentity = ecs.EntitiesWith<Identity, Health>();
 
 		REQUIRE(healthAndIdentity.size() == 1);
 	}
@@ -251,7 +251,7 @@ TEST_SUITE("Manager deleting entities")
 
 		ecs.RemoveEntity(e0);
 
-		REQUIRE(ecs.EntitiesWith(Identity()).size() == 1);
+		REQUIRE(ecs.EntitiesWith<Identity>().size() == 1);
 	}
 
 	TEST_CASE("Deleting an entity also deletes component data (bigger example)")
@@ -294,7 +294,7 @@ TEST_SUITE("Manager deleting entities")
 
 		ecs.RemoveEntity(e1);
 
-		REQUIRE(ecs.EntitiesWith(Identity(), Health()).size() == 2);
+		REQUIRE(ecs.EntitiesWith<Identity, Health>().size() == 2);
 	}
 
 	TEST_CASE("Deleting an entity and trying to access its data after")

--- a/src/ECSManager_tests.cpp
+++ b/src/ECSManager_tests.cpp
@@ -56,39 +56,39 @@ TEST_SUITE("Manager Components")
 
 	TEST_CASE("AddComponent works after component is registered")
 	{
-		ecs.RegisterComponent(Health());
+		ecs.RegisterComponent<Health>();
 		CHECK_NOTHROW(ecs.AddComponent(e, Health{ 10, 5 }));
 	}
 
 	TEST_CASE("HasComponent can find added components")
 	{
-		ecs.RegisterComponent(Identity());
+		ecs.RegisterComponent<Identity>();
 
-		REQUIRE(ecs.HasComponent(e, Health()) == true);
-		REQUIRE(ecs.HasComponent(e, Identity()) == false);
+		REQUIRE(ecs.HasComponent<Health>(e) == true);
+		REQUIRE(ecs.HasComponent<Identity>(e) == false);
 	}
 
 	TEST_CASE("GetComponent returns expected data")
 	{
-		Health* h = ecs.GetComponent(e, Health());
+		Health* h = ecs.GetComponent<Health>(e);
 		REQUIRE(h->max == 10);
 		REQUIRE(h->current == 5);
 	}
 
 	TEST_CASE("Modified component data persists")
 	{
-		Health* h = ecs.GetComponent(e, Health());
+		Health* h = ecs.GetComponent<Health>(e);
 		h->max = 15;
 		h->current = 12;
 
-		h = ecs.GetComponent(e, Health());
+		h = ecs.GetComponent<Health>(e);
 		REQUIRE(h->max == 15);
 		REQUIRE(h->current == 12);
 	}
 
 	TEST_CASE("GetComponent with unregistered component throws")
 	{
-		CHECK_THROWS_AS(ecs.GetComponent(e, AI()), const babs_ecs::ComponentNotRegisteredException);
+		CHECK_THROWS_AS(ecs.GetComponent<AI>(e), const babs_ecs::ComponentNotRegisteredException);
 	}
 
 	TEST_CASE("RemoveComponent removes the data")
@@ -97,14 +97,14 @@ TEST_SUITE("Manager Components")
 		ecs.AddComponent(e, Identity{ "babs2" });
 
 		// remove the existing health
-		ecs.RemoveComponent(e, Health());
+		ecs.RemoveComponent<Health>(e);
 
 		// verify health is gone
-		REQUIRE(ecs.HasComponent(e, Health()) == false);
-		REQUIRE(ecs.GetComponent(e, Health()) == nullptr);
+		REQUIRE(ecs.HasComponent<Health>(e) == false);
+		REQUIRE(ecs.GetComponent<Health>(e) == nullptr);
 
 		// still has Identity
-		auto identity = ecs.GetComponent(e, Identity());
+		auto identity = ecs.GetComponent<Identity>(e);
 		REQUIRE(identity->name == "babs2");
 	}
 
@@ -112,15 +112,15 @@ TEST_SUITE("Manager Components")
 	{
 		babs_ecs::ECSManager ecs;
 
-		ecs.RegisterComponent(Identity());
-		ecs.RegisterComponent(Health());
+		ecs.RegisterComponent<Identity>();
+		ecs.RegisterComponent<Health>();
 
 		babs_ecs::Entity e0 = ecs.CreateEntity();
 		Identity e0Ident = Identity();
 		e0Ident.name = "babs1";
 
 		// Nothing to really assert, it just shouldn't blow up.
-		ecs.RemoveComponent(e0, Health());
+		ecs.RemoveComponent<Health>(e0);
 	}
 }
 
@@ -130,8 +130,8 @@ TEST_SUITE("Manager Searching")
 
 	TEST_CASE("EntitiesWith finds 1 entity with Identity")
 	{
-		ecs.RegisterComponent(Identity());
-		ecs.RegisterComponent(Health());
+		ecs.RegisterComponent<Identity>();
+		ecs.RegisterComponent<Health>();
 
 		// set up entity 1
 		babs_ecs::Entity entity1 = ecs.CreateEntity();
@@ -174,14 +174,14 @@ TEST_SUITE("Manager Searching")
 		ecs.AddComponent<Health>(entity1, hp);
 
 		// Getting component
-		Health* storedHp = ecs.GetComponent(entity1, Health());
+		Health* storedHp = ecs.GetComponent<Health>(entity1);
 
 		REQUIRE(storedHp != nullptr);
 		REQUIRE(storedHp->current == hp.current);
 		REQUIRE(storedHp->max == hp.max);
 
-		ecs.RegisterComponent(Health());
-		ecs.RegisterComponent(Identity());
+		ecs.RegisterComponent<Health>();
+		ecs.RegisterComponent<Identity>();
 
 		babs_ecs::Entity e = ecs.CreateEntity();
 
@@ -200,8 +200,8 @@ TEST_SUITE("Manager Searching")
 		hp.current = 100;
 		hp.max = 100;
 
-		ecs.RegisterComponent(Identity());
-		ecs.RegisterComponent(Health());
+		ecs.RegisterComponent<Identity>();
+		ecs.RegisterComponent<Health>();
 
 		ecs.AddComponent(entity, ident);
 		ecs.AddComponent(entity, hp);
@@ -235,7 +235,7 @@ TEST_SUITE("Manager deleting entities")
 	{
 		babs_ecs::ECSManager ecs;
 
-		ecs.RegisterComponent(Identity());
+		ecs.RegisterComponent<Identity>();
 
 		babs_ecs::Entity e0 = ecs.CreateEntity();
 		Identity e0Ident;
@@ -258,8 +258,8 @@ TEST_SUITE("Manager deleting entities")
 	{
 		babs_ecs::ECSManager ecs;
 
-		ecs.RegisterComponent(Identity());
-		ecs.RegisterComponent(Health());
+		ecs.RegisterComponent<Identity>();
+		ecs.RegisterComponent<Health>();
 
 		babs_ecs::Entity e0 = ecs.CreateEntity();
 		Identity e0Ident = Identity();
@@ -301,8 +301,8 @@ TEST_SUITE("Manager deleting entities")
 	{
 		babs_ecs::ECSManager ecs;
 
-		ecs.RegisterComponent(Identity());
-		ecs.RegisterComponent(Health());
+		ecs.RegisterComponent<Identity>();
+		ecs.RegisterComponent<Health>();
 
 		babs_ecs::Entity e0 = ecs.CreateEntity();
 		Identity e0Ident = Identity();
@@ -313,7 +313,7 @@ TEST_SUITE("Manager deleting entities")
 
 		ecs.RemoveEntity(e0);
 
-		Identity* ident = ecs.GetComponent(e0, Identity());
+		Identity* ident = ecs.GetComponent<Identity>(e0);
 
 		REQUIRE(ident == nullptr);
 	}

--- a/src/benchmark.cpp
+++ b/src/benchmark.cpp
@@ -49,8 +49,8 @@ struct Tag {};
 void babsEcsTest(int entityCount, int iterationCount, int tagProb)
 {
 	babs_ecs::ECSManager ecs;
-	ecs.RegisterComponent(Identity());
-	ecs.RegisterComponent(Tag());
+	ecs.RegisterComponent<Identity>();
+	ecs.RegisterComponent<Tag>();
 
 	{
 		Timer timer;

--- a/src/benchmark.cpp
+++ b/src/benchmark.cpp
@@ -69,7 +69,7 @@ void babsEcsTest(int entityCount, int iterationCount, int tagProb)
 
         std::uint64_t sum = 0;
         for (int i = 0; i < iterationCount; ++i) {
-            auto entities = ecs.EntitiesWith(Identity{}, Tag{});
+            auto entities = ecs.EntitiesWith<Identity, Tag>();
             for (auto entity : entities)
             {
                 sum++;

--- a/src/events/EventManager_tests.cpp
+++ b/src/events/EventManager_tests.cpp
@@ -84,7 +84,7 @@ TEST_SUITE("Event Manager fires default ECS events")
 	TEST_CASE("Component Added")
 	{
 		bool eventCalled = false;
-		ecs.RegisterComponent(Identity());
+		ecs.RegisterComponent<Identity>();
 
 		e0Identity.name = "Babs1";
 		ecs.events.Subscribe<babs_ecs::ComponentAdded<Identity>>([&](const babs_ecs::ComponentAdded<Identity>& e) {
@@ -100,7 +100,7 @@ TEST_SUITE("Event Manager fires default ECS events")
 	TEST_CASE("Component Removed")
 	{
 		bool eventCalled = false;
-		ecs.RegisterComponent(Identity());
+		ecs.RegisterComponent<Identity>();
 
 		e0Identity.name = "Babs1";
 		ecs.AddComponent(e0, e0Identity);
@@ -110,7 +110,7 @@ TEST_SUITE("Event Manager fires default ECS events")
 			eventCalled = true;
 			});
 
-		ecs.RemoveComponent(e0, Identity());
+		ecs.RemoveComponent<Identity>(e0);
 
 		REQUIRE(eventCalled == true);
 	}


### PR DESCRIPTION
This branch turned into three things:
1. converting most templated calls from `Function(Type())` to `Function<Type>()`
2. took advantage of the c++17 `if constexpr` magic to convert `GetComponentNames` into a single function
3. added an entity searching example to the README, as well as some tutorial touch ups

The big thing is item 1, which lets us drop passing around default instances of components just so we can grab the type name. Item 2 was mostly a bonus thing I ran across while trying to switch the function over. One nice thing is we now have a single function to return all the component names instead of 3 functions.