### PR TITLE
Add default entity constructor

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -32,7 +32,9 @@ link_directories(
 # tests
 add_executable(tests
     src/tests.cpp
+    src/Entity_tests.cpp
     src/ECSManager_tests.cpp
+    src/babs_ecs_tests.cpp
     src/bitfield/bitfield_tests.cpp
     src/events/EventManager_tests.cpp
 )

--- a/src/ECSManager.hpp
+++ b/src/ECSManager.hpp
@@ -56,13 +56,13 @@ namespace babs_ecs
 		ECSManager()
 		{
 			this->bitIndex = 1;
-			this->entityIndex = 0;
+			this->entityIndex = 1;
 		}
 
 		// CreateEntity will initialize and return a new entity with no components.
 		Entity CreateEntity()
 		{
-			uint32_t entityId = 0;
+			uint32_t entityId = 1;
 
 			if (!this->unusedEntityIndices.empty())
 			{

--- a/src/ECSManager_tests.cpp
+++ b/src/ECSManager_tests.cpp
@@ -23,24 +23,33 @@ struct Health
 
 TEST_SUITE("Manager Setup")
 {
+    TEST_CASE("CreateEntity starts with entity UUID of 1")
+    {
+        babs_ecs::ECSManager ecs;
+
+        babs_ecs::Entity e = ecs.CreateEntity();
+
+        REQUIRE(e.UUID == 1);
+    }
+
 	TEST_CASE("CreateEntity returns componentless, unique entities")
 	{
 		babs_ecs::ECSManager ecs;
 
 		babs_ecs::Entity e0 = ecs.CreateEntity();
 		babs_ecs::Entity e1 = ecs.CreateEntity();
-		ecs.CreateEntity(); // 2
 		ecs.CreateEntity(); // 3
+		ecs.CreateEntity(); // 4
 		babs_ecs::Entity e4 = ecs.CreateEntity();
 
 		REQUIRE(e0.bitfield == 0);
-		REQUIRE(e0.UUID == 0);
+		REQUIRE(e0.UUID == 1);
 
 		REQUIRE(e1.bitfield == 0);
-		REQUIRE(e1.UUID == 1);
+		REQUIRE(e1.UUID == 2);
 
 		REQUIRE(e4.bitfield == 0);
-		REQUIRE(e4.UUID == 4);
+		REQUIRE(e4.UUID == 5);
 	}
 }
 
@@ -218,17 +227,17 @@ TEST_SUITE("Manager deleting entities")
 	{
 		babs_ecs::ECSManager ecs;
 
-		babs_ecs::Entity zero = ecs.CreateEntity(); // 0
-		babs_ecs::Entity one = ecs.CreateEntity(); // 1
-		babs_ecs::Entity two = ecs.CreateEntity(); // 2
-		babs_ecs::Entity three = ecs.CreateEntity(); // 3
+		babs_ecs::Entity zero = ecs.CreateEntity(); // 1
+		babs_ecs::Entity one = ecs.CreateEntity(); // 2
+		babs_ecs::Entity two = ecs.CreateEntity(); // 3
+		babs_ecs::Entity three = ecs.CreateEntity(); // 4
 
 		ecs.RemoveEntity(two);
 
 		babs_ecs::Entity newTwo = ecs.CreateEntity(); // should be 2 again
-		REQUIRE(newTwo.UUID == 2);
+		REQUIRE(newTwo.UUID == 3);
 		babs_ecs::Entity four = ecs.CreateEntity();
-		REQUIRE(four.UUID == 4);
+		REQUIRE(four.UUID == 5);
 	}
 
 	TEST_CASE("Deleting an entity also deletes component data")

--- a/src/Entity.hpp
+++ b/src/Entity.hpp
@@ -8,6 +8,8 @@ namespace babs_ecs
         bitfield::Bitfield bitfield;
         uint32_t UUID;
 
+        Entity() : Entity(0) {}
+
         Entity(uint32_t uuid)
         {
             bitfield = 0;

--- a/src/Entity_tests.cpp
+++ b/src/Entity_tests.cpp
@@ -17,7 +17,7 @@ TEST_SUITE("Entity class")
 
     TEST_CASE("Entity can be used in a map container")
     {
-        std::unordered_map<char, babs_ecs::Entity> items = {};
+        std::map<char, babs_ecs::Entity> items = {};
         items['a'] = babs_ecs::Entity(5);
 
         REQUIRE(items['a'].UUID == 5);

--- a/src/Entity_tests.cpp
+++ b/src/Entity_tests.cpp
@@ -1,0 +1,25 @@
+#include "doctest.h"
+
+#include "ECSManager.hpp"
+
+#include <map>
+
+
+TEST_SUITE("Entity class")
+{
+	TEST_CASE("Entity() returns a dummy/non-tracked entity")
+	{
+		babs_ecs::Entity e = babs_ecs::Entity();
+
+		REQUIRE(e.bitfield == 0);
+		REQUIRE(e.UUID == 0);
+	}
+
+    TEST_CASE("Entity can be used in a map container")
+    {
+        std::unordered_map<char, babs_ecs::Entity> items = {};
+        items['a'] = babs_ecs::Entity(5);
+
+        REQUIRE(items['a'].UUID == 5);
+    }
+}

--- a/src/babs_ecs.hpp
+++ b/src/babs_ecs.hpp
@@ -1,0 +1,1 @@
+ECSManager.hpp

--- a/src/babs_ecs.hpp
+++ b/src/babs_ecs.hpp
@@ -1,1 +1,1 @@
-ECSManager.hpp
+#include "ECSManager.hpp"

--- a/src/babs_ecs_tests.cpp
+++ b/src/babs_ecs_tests.cpp
@@ -1,0 +1,13 @@
+#include "doctest.h"
+
+#include "babs_ecs.hpp"
+
+
+TEST_CASE("Confirming symlink babs_ecs -> ECSManager works")
+{
+    babs_ecs::ECSManager ecs;
+
+    babs_ecs::Entity e = ecs.CreateEntity();
+
+    REQUIRE(e.UUID == 1);
+}

--- a/src/events/EventManager_tests.cpp
+++ b/src/events/EventManager_tests.cpp
@@ -72,7 +72,7 @@ TEST_SUITE("Event Manager fires default ECS events")
 	{
 		bool entityCreatedEventFired = false;
 		ecs.events.Subscribe<babs_ecs::EntityCreated>([&](const babs_ecs::EntityCreated& e) {
-			REQUIRE(e.entity.UUID == 0);
+			REQUIRE(e.entity.UUID == 1);
 			entityCreatedEventFired = true;
 			});
 


### PR DESCRIPTION
Three changes:
* added default constructor so the Entity class can be used in containers like `std::map`
* updated ECSManager to start UUID counting at 1 so that 0 can be used with the default constructor
* added `babs_ecs.hpp` -> `ECSManager.hpp` symlink so that users can do `#include "babs_ecs.hpp"` - dunno if this works for windows

Added a test in for the `std::map` scenario. All it needed to do is be able to compile to prove it works.
